### PR TITLE
Fix arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,12 @@ go build -o clickhouse_sinker bin/main.go
 * [x] Float32, Float64
 * [x] String
 * [x] FixedString
-* [x] DateTime (UInt32), Date(UInt16)
+* [x] DateTime(UInt32), Date(UInt16)
+* [x] Array(UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64)
+* [x] Array(Float32, Float64)
+* [x] Array(String)
+* [x] Array(FixedString)
+* [x] Array(DateTime(UInt32), Date(UInt16))
 
 
 ## Configuration

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/json-iterator/go v0.0.0-20170822023901-cdbd2ed81059
 	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
 	github.com/k0kubun/pp v2.2.0+incompatible
-	github.com/kshvakov/clickhouse v0.0.0-20181208125010-1fd26158e61b
+	github.com/kshvakov/clickhouse v1.3.9
 	github.com/mattn/go-colorable v0.1.1 // indirect
 	github.com/mattn/go-isatty v0.0.7 // indirect
 	github.com/pierrec/lz4 v0.0.0-20190507090305-b8e3f78e075c // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/k0kubun/pp v2.2.0+incompatible h1:CJdCM8D10voAW/MDCZwD7b90vL3CUHjq0ko
 github.com/k0kubun/pp v2.2.0+incompatible/go.mod h1:GWse8YhT0p8pT4ir3ZgBbfZild3tgzSScAn6HmfYukg=
 github.com/kshvakov/clickhouse v0.0.0-20181208125010-1fd26158e61b h1:sVDQQDtD63gm8nPCFGpNVw/eMpJyCXXsBEaEBiTFQxQ=
 github.com/kshvakov/clickhouse v0.0.0-20181208125010-1fd26158e61b/go.mod h1:DMzX7FxRymoNkVgizH0DWAL8Cur7wHLgx3MUnGwJqpE=
+github.com/kshvakov/clickhouse v1.3.9 h1:fGK8joFwxh/9HHOe+EDa0/7WnNiKYTLrjE46IhERe1U=
+github.com/kshvakov/clickhouse v1.3.9/go.mod h1:DMzX7FxRymoNkVgizH0DWAL8Cur7wHLgx3MUnGwJqpE=
 github.com/mattn/go-colorable v0.1.1 h1:G1f5SKeVxmagw/IyvzvtZE4Gybcc4Tr1tf7I8z0XgOg=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=

--- a/model/metric.go
+++ b/model/metric.go
@@ -3,6 +3,7 @@ package model
 type Metric interface {
 	Get(key string) interface{}
 	GetString(key string) string
+	GetArray(key string, t string) []interface{}
 	GetFloat(key string) float64
 	GetInt(key string) int64
 }

--- a/parser/gjson.go
+++ b/parser/gjson.go
@@ -25,19 +25,10 @@ func (c *GjsonMetric) GetString(key string) string {
 	return gjson.Get(c.raw, key).String()
 }
 
-func (c *GjsonMetric) GetStringArray(key string) []string {
-	strings := gjson.Get(c.raw, key).Array()
-	results := make([]string, 0, len(strings))
-	for i := range strings {
-		results = append(results, strings[i].String())
-	}
-	return results
-}
-
 func (c *GjsonMetric) GetArray(key string, t string) []interface{} {
 	slice := gjson.Get(c.raw, key).Array()
 	results := make([]interface{}, 0, len(slice))
-	switch slice[0].Type {
+	switch t {
 	default:
 		return []interface{}{}
 	case "float":

--- a/parser/gjson.go
+++ b/parser/gjson.go
@@ -25,6 +25,39 @@ func (c *GjsonMetric) GetString(key string) string {
 	return gjson.Get(c.raw, key).String()
 }
 
+func (c *GjsonMetric) GetStringArray(key string) []string {
+	strings := gjson.Get(c.raw, key).Array()
+	results := make([]string, 0, len(strings))
+	for i := range strings {
+		results = append(results, strings[i].String())
+	}
+	return results
+}
+
+func (c *GjsonMetric) GetArray(key string, t string) []interface{} {
+	slice := gjson.Get(c.raw, key).Array()
+	results := make([]interface{}, 0, len(slice))
+	switch slice[0].Type {
+	default:
+		return []interface{}{}
+	case "float":
+		for i := range slice {
+			results = append(results, slice[i].Float())
+		}
+		return results
+	case "int":
+		for i := range slice {
+			results = append(results, slice[i].Int())
+		}
+		return results
+	case "string":
+		for i := range slice {
+			results = append(results, slice[i].String())
+		}
+		return results
+	}
+}
+
 func (c *GjsonMetric) GetFloat(key string) float64 {
 	return gjson.Get(c.raw, key).Float()
 }

--- a/parser/json.go
+++ b/parser/json.go
@@ -57,6 +57,47 @@ func (c *JsonMetric) GetString(key string) string {
 	return ""
 }
 
+func (c *JsonMetric) GetArray(key string, t string) []interface{} {
+	//判断object
+	val, _ := c.mp[key]
+	switch t {
+	case "string":
+		return val.([]interface{})
+
+	case "float":
+		switch val.(type) {
+		case []float64:
+			return val.([]interface{})
+
+		case []string:
+			results := make([]interface{}, 0, len(val.([]string)))
+			for i := range val.([]string) {
+				result, _ := strconv.ParseFloat(val.([]string)[i], 64)
+				results = append(results, result)
+			}
+			return results
+		}
+	case "int":
+		switch val.(type) {
+		case []float64:
+			results := make([]interface{}, 0, len(val.([]float64)))
+			for i := range val.([]float64) {
+				results = append(results, int64(val.([]float64)[i]))
+			}
+			return results
+
+		case []string:
+			results := make([]interface{}, 0, len(val.([]string)))
+			for i := range val.([]string) {
+				result, _ := strconv.ParseInt(val.([]string)[i], 10, 64)
+				results = append(results, result)
+			}
+			return results
+		}
+	}
+	return []interface{}{}
+}
+
 func (c *JsonMetric) GetFloat(key string) float64 {
 	val, _ := c.mp[key]
 	if val == nil {

--- a/util/value.go
+++ b/util/value.go
@@ -14,6 +14,12 @@ func GetValueByType(metric model.Metric, cwt *model.ColumnWithType) interface{} 
 		return metric.GetFloat(cwt.Name)
 	case "string":
 		return metric.GetString(cwt.Name)
+	case "stringArray":
+		return metric.GetArray(cwt.Name, "string")
+	case "intArray":
+		return metric.GetArray(cwt.Name, "int")
+	case "floatArray":
+		return metric.GetArray(cwt.Name, "float")
 	//never happen
 	default:
 		return ""
@@ -24,10 +30,16 @@ func switchType(typ string) string {
 	switch typ {
 	case "Date", "DateTime", "UInt8", "UInt16", "UInt32", "UInt64", "Int8", "Int16", "Int32", "Int64":
 		return "int"
+	case "Array(Date)", "Array(DateTime)", "Array(UInt8)", "Array(UInt16)", "Array(UInt32)", "Array(UInt64)", "Array(Int8)", "Array(Int16)", "Array(Int32)", "Array(Int64)":
+		return "intArray"
 	case "String", "FixString":
 		return "string"
+	case "Array(String)", "Array(FixString)":
+		return "stringArray"
 	case "Float32", "Float64":
 		return "float"
+	case "Array(Float32)", "Array(Float64)":
+		return "floatArray"
 	default:
 		panic("unsupport type " + typ)
 	}

--- a/util/value.go
+++ b/util/value.go
@@ -2,24 +2,26 @@ package util
 
 import (
 	"github.com/housepower/clickhouse_sinker/model"
+	"strings"
 )
 
 //这里对metric的value类型，只有三种情况， （float64，string，map[string]interface{})
 func GetValueByType(metric model.Metric, cwt *model.ColumnWithType) interface{} {
 	swType := switchType(cwt.Type)
+	name := strings.Replace(cwt.Name, ".", "\\.", -1)
 	switch swType {
 	case "int":
-		return metric.GetInt(cwt.Name)
+		return metric.GetInt(name)
 	case "float":
-		return metric.GetFloat(cwt.Name)
+		return metric.GetFloat(name)
 	case "string":
-		return metric.GetString(cwt.Name)
+		return metric.GetString(name)
 	case "stringArray":
-		return metric.GetArray(cwt.Name, "string")
+		return metric.GetArray(name, "string")
 	case "intArray":
-		return metric.GetArray(cwt.Name, "int")
+		return metric.GetArray(name, "int")
 	case "floatArray":
-		return metric.GetArray(cwt.Name, "float")
+		return metric.GetArray(name, "float")
 	//never happen
 	default:
 		return ""


### PR DESCRIPTION
The clickhouse library required updating to support arrays. Also added filtering for metrics that contain `.`s. With gjson you have to escape them