### PR TITLE
remove unnecessary newticker

### DIFF
--- a/task/task.go
+++ b/task/task.go
@@ -64,7 +64,6 @@ FOR:
 				service.Lock()
 				service.flush(msgs)
 				msgs = make([]model.Metric, 0, 100000)
-				tick = time.NewTicker(time.Duration(service.FlushInterval) * time.Second)
 				service.Unlock()
 			}
 		case <-tick.C:


### PR DESCRIPTION
I found that there are several NewTicker assigned to the same variable in task.go.  So I remove the redundant one.