### PR TITLE
feat: support parsing nested json object

### DIFF
--- a/conf/tasks/daily_request.json
+++ b/conf/tasks/daily_request.json
@@ -1,0 +1,30 @@
+{
+  "name": "daily_request",
+  "kafka": "kfk",
+  "topic": "topic",
+  "earliest": true,
+  "consumerGroup": "group",
+  "parser": "gjson_extend",
+  "clickhouse": "ch",
+  "tableName": "daily",
+  "dims": [
+    {
+      "name": "day",
+      "type": "Date",
+      "kafkaField": "day"
+    },
+    {
+      "name": "level",
+      "type": "String",
+      "kafkaField": "data_level"
+    },
+    {
+      "name": "total",
+      "type": "UInt64",
+      "kafkaField": "data_total"
+    }
+  ],
+  "@desc_of_exclude_columns": "this columns will be excluded by insert SQL ",
+  "excludeColumns": [],
+  "bufferSize": 2
+}

--- a/creator/config.go
+++ b/creator/config.go
@@ -160,12 +160,14 @@ type Task struct {
 	ExcludeColumns []string
 
 	Dims []struct {
-		Name string
-		Type string
+		Name       string
+		Type       string
+		KafkaField string
 	} `json:"dims"`
 	Metrics []struct {
-		Name string
-		Type string
+		Name       string
+		Type       string
+		KafkaField string
 	} `json:"metrics"`
 
 	FlushInterval int `json:"flushInterval,omitempty"`

--- a/model/metric.go
+++ b/model/metric.go
@@ -33,6 +33,7 @@ type DimMetrics struct {
 
 // ColumnWithType
 type ColumnWithType struct {
-	Name string
-	Type string
+	Name       string
+	Type       string
+	KafkaField string
 }

--- a/parser/gjson_extend.go
+++ b/parser/gjson_extend.go
@@ -70,9 +70,9 @@ func injectObject(prefix string, result map[string]interface{}, t gjson.Result) 
 	t.ForEach(func(key gjson.Result, value gjson.Result) bool {
 		switch value.Type {
 		case gjson.JSON:
-			injectObject(prefix+"_"+key.String(), result, value)
+			injectObject(prefix+"."+key.String(), result, value)
 		default:
-			result[prefix+"_"+key.String()] = value.Value()
+			result[prefix+"."+key.String()] = value.Value()
 		}
 		return true
 	})

--- a/parser/gjson_test.go
+++ b/parser/gjson_test.go
@@ -19,7 +19,7 @@ func TestGjsonArrayInt(t *testing.T) {
 	parser := NewParser("gjson", nil, "")
 	metric := parser.Parse(jsonSample)
 
-	arr := metric.GetArray("mp_a", "int").([]int64)
+	arr := metric.GetArray("mp.a", "int").([]int64)
 	expected := []int64{1, 2, 3}
 	for i := range arr {
 		assert.Equal(t, arr[i], expected[i])
@@ -39,7 +39,7 @@ func TestGjsonArrayString(t *testing.T) {
 	parser := NewParser("gjson", nil, "")
 	metric := parser.Parse(jsonSample)
 
-	arr := metric.GetArray("mps_a", "string").([]string)
+	arr := metric.GetArray("mps.a", "string").([]string)
 	expected := []string{"aa", "bb", "cc"}
 	for i := range arr {
 		assert.Equal(t, arr[i], expected[i])
@@ -59,7 +59,7 @@ func TestGjsonArrayFloat(t *testing.T) {
 	parser := NewParser("gjson", nil, "")
 	metric := parser.Parse(jsonSample)
 
-	arr := metric.GetArray("mp_f", "float").([]float64)
+	arr := metric.GetArray("mp.f", "float").([]float64)
 	expected := []float64{1.11, 2.22, 3.33}
 	for i := range arr {
 		assert.Equal(t, arr[i], expected[i])

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -115,7 +115,7 @@ func TestGjsonExtend(t *testing.T) {
 	parser := NewParser("gjson_extend", nil, ",")
 	metric := parser.Parse(jsonSample)
 
-	arr := metric.GetArray("mp_a", "int").([]int64)
+	arr := metric.GetArray("mp.a", "int").([]int64)
 	expected := []int64{1, 2, 3}
 	for i := range arr {
 		assert.Equal(t, arr[i], expected[i])

--- a/util/value.go
+++ b/util/value.go
@@ -25,7 +25,7 @@ import (
 func GetValueByType(metric model.Metric, cwt *model.ColumnWithType) interface{} {
 	swType := switchType(cwt.Type)
 	var name string
-	if name = strings.Replace(cwt.KafkaField, ".", "\\.", -1); name == "" {
+	if name = cwt.KafkaField; name == "" {
 		name = strings.Replace(cwt.Name, ".", "\\.", -1)
 	}
 	switch swType {

--- a/util/value.go
+++ b/util/value.go
@@ -24,7 +24,10 @@ import (
 // There are only three cases for the value type of metric, (float64, string, map [string] interface {})
 func GetValueByType(metric model.Metric, cwt *model.ColumnWithType) interface{} {
 	swType := switchType(cwt.Type)
-	name := strings.Replace(cwt.Name, ".", "\\.", -1)
+	var name string
+	if name = strings.Replace(cwt.KafkaField, ".", "\\.", -1); name == "" {
+		name = strings.Replace(cwt.Name, ".", "\\.", -1)
+	}
 	switch swType {
 	case "int":
 		return metric.GetInt(name)


### PR DESCRIPTION
I suggest we should put a new field name **kafkaField** in **dims** and **metrics** in order to parse nested json object because this has different name from clickhouse table columns and we cannot use name in **dims**.

For example, I have clickhouse table and data json object that sink into table below 

```
CREATE TABLE daily (
    day Date,
    level String,
    total UInt64
  ) ENGINE = SummingMergeTree(total)
  PARTITION BY (day, level)
  ORDER BY day;
```

```
{
   "day":1565712000,
   "data":{
      "level":"3",
      "total":1
   }
}
```
