### PR TITLE
remove workerpool

### DIFF
--- a/util/workerpool.go
+++ b/util/workerpool.go
@@ -1,0 +1,61 @@
+package util
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// WorkerPool is a blocked worker pool inspired by https://github.com/gammazero/workerpool/
+type WorkerPool struct {
+	inNums  uint64
+	outNums uint64
+
+	maxWorkers int
+	workChan   chan struct{}
+
+	stopOnce sync.Once
+	stopped  int32
+}
+
+// New creates and starts a pool of worker goroutines.
+func NewWorkerPool(maxWorkers int) *WorkerPool {
+	return &WorkerPool{
+		maxWorkers: maxWorkers,
+		workChan:   make(chan struct{}, maxWorkers),
+	}
+}
+
+var (
+	// ErrorStopped when stopped
+	ErrorStopped = errors.New("WorkerPool already stopped")
+)
+
+// Submit enqueues a function for a worker to execute.
+// Submit will block regardless if there is no free workers.
+func (w *WorkerPool) Submit(fn func()) (err error) {
+	if atomic.LoadInt32(&w.stopped) == 1 {
+		return ErrorStopped
+	}
+
+	atomic.AddUint64(&w.inNums, 1)
+	w.workChan <- struct{}{}
+	go func() {
+		fn()
+		<-w.workChan
+		atomic.AddUint64(&w.outNums, 1)
+	}()
+	return nil
+}
+
+// StopWait stops the worker pool and waits for all queued tasks tasks to complete.
+func (w *WorkerPool) StopWait() {
+	w.stopOnce.Do(func() {
+		atomic.StoreInt32(&w.stopped, 1)
+	})
+
+	for atomic.LoadUint64(&w.inNums) > atomic.LoadUint64(&w.outNums) {
+		time.Sleep(3 * time.Millisecond)
+	}
+}

--- a/util/workerpool_test.go
+++ b/util/workerpool_test.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestWorkerPool(t *testing.T) {
+	wp := NewWorkerPool(3)
+	requests := []string{"alpha", "beta", "gamma", "delta", "epsilon"}
+
+	rspChan := make(chan string, len(requests))
+	for _, r := range requests {
+		r := r
+		wp.Submit(func() {
+			rspChan <- r
+		})
+	}
+	wp.StopWait()
+
+	close(rspChan)
+	rspSet := map[string]struct{}{}
+	for rsp := range rspChan {
+		rspSet[rsp] = struct{}{}
+	}
+	if len(rspSet) < len(requests) {
+		t.Fatal("Did not handle all requests")
+	}
+	for _, req := range requests {
+		if _, ok := rspSet[req]; !ok {
+			t.Fatal("Missing expected values:", req)
+		}
+	}
+}


### PR DESCRIPTION
```
// Submit will not block regardless of the number of tasks submitted.  Each
// task is immediately given to an available worker or to a newly started
// worker.  If there are no available workers, and the maximum number of
// workers are already created, then the task is put onto a waiting queue.
//
```

https://github.com/gammazero/workerpool/blob/master/workerpool.go#L89

`workerpool` has an endless deque, which will lead memory cost too much when flush is too slow. we need block wait.