### PR TITLE
Batch group ensures batches be committed orderly

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ clickhouse_sinker is a sinker program that transfer kafka message into [ClickHou
 
 ## Features
 
+- Uses Native ClickHouse client-server TCP protocol, with higher performance than HTTP.
 - Easy to use and deploy, you don't need write any hard code, just care about the configuration file
 - Support multiple parsers: csv, fastjson, gjson.
 - Support multiple Kafka client: sarama, kafka-go.
@@ -15,9 +16,9 @@ clickhouse_sinker is a sinker program that transfer kafka message into [ClickHou
 - Support multiply kafka and ClickHouse clusters.
 - Bulk insert (by config `bufferSize` and `flushInterval`).
 - Parse messages concurrently (by config `concurrentParsers`).
-- Loop write (when some node crashes, it will retry write the data to the other healthy node)
-- Uses Native ClickHouse client-server TCP protocol, with higher performance than HTTP.
-- At least once message guarantee, [more info](https://github.com/housepower/clickhouse_sinker/issues/76) about it.
+- Write batches concurrently.
+- Every batch is routed to a determined clickhouse node. Exit if loop write failed.
+- At least once delivery guarantee, [more info](https://github.com/housepower/clickhouse_sinker/issues/76) about it.
 
 ## Install && Run
 

--- a/bin/main.go
+++ b/bin/main.go
@@ -218,8 +218,14 @@ func (s *Sinker) Init() (err error) {
 
 	util.InitGlobalTimerWheel()
 	util.InitGlobalWorkerPool1(s.cfg.Common.ConcurrentParsers)
+	blockSize := s.cfg.Common.BufferSize
+	for _, taskCfg := range s.cfg.Tasks {
+		if blockSize < taskCfg.BufferSize {
+			blockSize = taskCfg.BufferSize
+		}
+	}
 	for ckName, ckCfg := range s.cfg.Clickhouse {
-		if err = pool.InitConn(ckName, ckCfg.Host, ckCfg.Port, ckCfg.DB, ckCfg.Username, ckCfg.Password, ckCfg.DsnParams); err != nil {
+		if err = pool.InitConn(ckName, ckCfg.Host, ckCfg.Port, ckCfg.DB, ckCfg.Username, ckCfg.Password, ckCfg.DsnParams, blockSize); err != nil {
 			return
 		}
 	}

--- a/bin/main.go
+++ b/bin/main.go
@@ -217,7 +217,7 @@ func (s *Sinker) Init() (err error) {
 	}
 
 	util.InitGlobalTimerWheel()
-	util.InitGlobalWorkerPool1(s.cfg.Common.ConcurrentParsers)
+	util.InitGlobalParsingPool(s.cfg.Common.ConcurrentParsers)
 	blockSize := s.cfg.Common.BufferSize
 	for _, taskCfg := range s.cfg.Tasks {
 		if blockSize < taskCfg.BufferSize {
@@ -233,7 +233,7 @@ func (s *Sinker) Init() (err error) {
 	for _, taskCfg := range s.cfg.Tasks {
 		totalConn += pool.GetNumConn(taskCfg.Clickhouse)
 	}
-	util.InitGlobalWorkerPool2(totalConn)
+	util.InitGlobalWritingPool(totalConn)
 
 	s.tasks = GenTasks(s.cfg)
 	for _, t := range s.tasks {
@@ -262,8 +262,8 @@ func (s *Sinker) Close() {
 		s.tasks[i].Stop()
 	}
 
-	util.GlobalWorkerPool1.StopWait()
-	util.GlobalWorkerPool2.StopWait()
+	util.GlobalParsingPool.StopWait()
+	util.GlobalWritingPool.StopWait()
 	util.GlobalTimerWheel.Stop()
 
 	if s.pusher != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -206,8 +206,13 @@ func (config *Config) normallize() {
 		config.Statistics.PushGateWayAddrs = strings.Split(pgwAddrs, ",")
 	}
 	if config.Statistics.Enable {
-		if config.Statistics.PushInterval == 0 {
+		if config.Statistics.PushInterval <= 0 {
 			config.Statistics.PushInterval = 10
+		}
+	}
+	for _, chConfig := range config.Clickhouse {
+		if chConfig.RetryTimes <=0 {
+			chConfig.RetryTimes = 6
 		}
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -211,7 +211,7 @@ func (config *Config) normallize() {
 		}
 	}
 	for _, chConfig := range config.Clickhouse {
-		if chConfig.RetryTimes <=0 {
+		if chConfig.RetryTimes <= 0 {
 			chConfig.RetryTimes = 6
 		}
 	}

--- a/input/kafka_go.go
+++ b/input/kafka_go.go
@@ -79,15 +79,15 @@ LOOP_KAFKA_GO:
 		if msg, err = k.r.FetchMessage(ctx); err != nil {
 			switch errors.Cause(err) {
 			case context.Canceled:
-				log.Infof("%s Kafka.Run quit due to context has been canceled", k.taskCfg.Name)
+				log.Infof("%s: Kafka.Run quit due to context has been canceled", k.taskCfg.Name)
 				break LOOP_KAFKA_GO
 			case io.EOF:
-				log.Infof("%s Kafka.Run quit due to reader has been closed", k.taskCfg.Name)
+				log.Infof("%s: Kafka.Run quit due to reader has been closed", k.taskCfg.Name)
 				break LOOP_KAFKA_GO
 			default:
 				statistics.ConsumeMsgsErrorTotal.WithLabelValues(k.taskCfg.Name).Inc()
 				err = errors.Wrap(err, "")
-				log.Errorf("%s Kafka.Run got error %+v", k.taskCfg.Name, err)
+				log.Errorf("%s: Kafka.Run got error %+v", k.taskCfg.Name, err)
 				continue
 			}
 		}

--- a/input/kafka_sarama.go
+++ b/input/kafka_sarama.go
@@ -52,9 +52,9 @@ func (h MyConsumerGroupHandler) Setup(sess sarama.ConsumerGroupSession) error {
 	return nil
 }
 func (h MyConsumerGroupHandler) Cleanup(_ sarama.ConsumerGroupSession) error {
-	log.Infof("%s consumer group %s rebalanced", h.k.taskCfg.Name, h.k.taskCfg.ConsumerGroup)
+	log.Infof("%s: consumer group %s rebalanced", h.k.taskCfg.Name, h.k.taskCfg.ConsumerGroup)
 	//TODO: Flush all rings helps to consuming duplicated messages?
-	time.Sleep(5 * time.Second)
+	time.Sleep(1 * time.Second)
 	return nil
 }
 
@@ -124,15 +124,15 @@ LOOP_SARAMA:
 		if err := k.cg.Consume(ctx, []string{k.taskCfg.Topic}, handler); err != nil {
 			switch errors.Cause(err) {
 			case context.Canceled:
-				log.Infof("%s Kafka.Run quit due to context has been canceled", k.taskCfg.Name)
+				log.Infof("%s: Kafka.Run quit due to context has been canceled", k.taskCfg.Name)
 				break LOOP_SARAMA
 			case sarama.ErrClosedConsumerGroup:
-				log.Infof("%s Kafka.Run quit due to consumer group has been closed", k.taskCfg.Name)
+				log.Infof("%s: Kafka.Run quit due to consumer group has been closed", k.taskCfg.Name)
 				break LOOP_SARAMA
 			default:
 				statistics.ConsumeMsgsErrorTotal.WithLabelValues(k.taskCfg.Name).Inc()
 				err = errors.Wrap(err, "")
-				log.Errorf("%s Kafka.Run got error %+v", k.taskCfg.Name, err)
+				log.Errorf("%s: Kafka.Run got error %+v", k.taskCfg.Name, err)
 				continue
 			}
 		}

--- a/input/kafka_sarama.go
+++ b/input/kafka_sarama.go
@@ -52,7 +52,7 @@ func (h MyConsumerGroupHandler) Setup(sess sarama.ConsumerGroupSession) error {
 	return nil
 }
 func (h MyConsumerGroupHandler) Cleanup(_ sarama.ConsumerGroupSession) error {
-	log.Infof("%s: consumer group %s rebalanced", h.k.taskCfg.Name, h.k.taskCfg.ConsumerGroup)
+	log.Infof("%s: consumer group %s cleanup", h.k.taskCfg.Name, h.k.taskCfg.ConsumerGroup)
 	//TODO: Flush all rings helps to consuming duplicated messages?
 	time.Sleep(1 * time.Second)
 	return nil

--- a/input/kafka_sarama.go
+++ b/input/kafka_sarama.go
@@ -18,6 +18,7 @@ package input
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/Shopify/sarama"
 	"github.com/pkg/errors"
@@ -53,6 +54,7 @@ func (h MyConsumerGroupHandler) Setup(sess sarama.ConsumerGroupSession) error {
 func (h MyConsumerGroupHandler) Cleanup(_ sarama.ConsumerGroupSession) error {
 	log.Infof("%s consumer group %s rebalanced", h.k.taskCfg.Name, h.k.taskCfg.ConsumerGroup)
 	//TODO: Flush all rings helps to consuming duplicated messages?
+	time.Sleep(5 * time.Second)
 	return nil
 }
 

--- a/model/message.go
+++ b/model/message.go
@@ -31,14 +31,14 @@ type Batch struct {
 	Group    *BatchGroup
 }
 
-//BatchGroup consists of multiple batchs.
-//The `before` relationship could be impossilbe if messages of a partition are distributed to multiple batchs.
-//So thoese batchs need to be committed after ALL of them have been written to clickhouse.
+//BatchGroup consists of multiple batches.
+//The `before` relationship could be impossilbe if messages of a partition are distributed to multiple batches.
+//So those batches need to be committed after ALL of them have been written to clickhouse.
 type BatchGroup struct {
 	Batchs    []*Batch
 	Offsets   []int64
 	Sys       *BatchSys
-	PendWrite int32 //how many batchs in this group are pending to wirte to ClickHouse
+	PendWrite int32 //how many batches in this group are pending to wirte to ClickHouse
 }
 
 type BatchSys struct {

--- a/model/message.go
+++ b/model/message.go
@@ -2,6 +2,8 @@ package model
 
 import (
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -25,16 +27,83 @@ type Batch struct {
 	MsgRows  []MsgRow
 	BatchIdx int64
 	RealSize int
+	Group    *BatchGroup
 }
 
-func (b Batch) Size() int {
+//BatchGroup consists of multiple batchs. The `before` relationship could be impossilbe if messages of a partition are distributed to multiple batchs. So thoese batchs need to be committed after ALL of them have been written to clickhouse.
+type BatchGroup struct {
+	Batchs    []*Batch
+	Offsets   []int64
+	Sys       *BatchSys
+	PendWrite int32 //how many batchs in this group are pending to wirte to ClickHouse
+}
+
+type BatchSys struct {
+	mux      sync.Mutex
+	groups   []*BatchGroup
+	fnCommit func(partition int, offset int64)
+}
+
+func NewBatchSys(fnCommit func(partition int, offset int64)) *BatchSys {
+	return &BatchSys{fnCommit: fnCommit}
+}
+
+func (bs *BatchSys) TryCommit() {
+	bs.mux.Lock()
+	defer bs.mux.Unlock()
+	var i int
+	var grp *BatchGroup
+	// ensure groups be committed orderly
+LOOP:
+	for i, grp = range bs.groups {
+		if atomic.LoadInt32(&grp.PendWrite) != 0 {
+			break LOOP
+		}
+		// commit the whole group
+		for j, off := range grp.Offsets {
+			bs.fnCommit(j, off+1)
+		}
+	}
+	bs.groups = bs.groups[i:]
+}
+
+func (bs *BatchSys) NewBatchGroup() *BatchGroup {
+	bg := &BatchGroup{Sys: bs}
+	bs.mux.Lock()
+	bs.groups = append(bs.groups, bg)
+	bs.mux.Unlock()
+	return bg
+}
+
+func (bg *BatchGroup) NewBatch(batchSize int, cap int) (batch *Batch) {
+	b := &Batch{
+		MsgRows: make([]MsgRow, batchSize, cap),
+		Group:   bg,
+	}
+	bg.Batchs = append(bg.Batchs, b)
+	atomic.AddInt32(&bg.PendWrite, 1)
+	return b
+}
+
+func (bg *BatchGroup) UpdateOffset(partition int, offset int64) bool {
+	gap := partition + 1 - len(bg.Offsets)
+	for i := 0; i < gap; i++ {
+		bg.Offsets = append(bg.Offsets, -1)
+	}
+	if offset <= bg.Offsets[partition] {
+		return false
+	}
+	bg.Offsets[partition] = offset
+	return true
+}
+
+func (b *Batch) Size() int {
 	return len(b.MsgRows)
 }
 
-func NewBatch(batchSize int, cap int) (batch Batch) {
-	return Batch{
-		MsgRows: make([]MsgRow, batchSize, cap),
-	}
+func (b *Batch) Commit() {
+	atomic.AddInt32(&b.Group.PendWrite, -1)
+	b.Group.Sys.TryCommit()
 }
 
 func MetricToRow(metric Metric, msg InputMessage, dims []*ColumnWithType) (row []interface{}) {

--- a/model/message.go
+++ b/model/message.go
@@ -61,7 +61,9 @@ LOOP:
 		}
 		// commit the whole group
 		for j, off := range grp.Offsets {
-			bs.fnCommit(j, off+1)
+			if off >= 0 {
+				bs.fnCommit(j, off)
+			}
 		}
 	}
 	bs.groups = bs.groups[i:]

--- a/output/clickhouse.go
+++ b/output/clickhouse.go
@@ -209,6 +209,6 @@ func (c *ClickHouse) initSchema() (err error) {
 	c.prepareSQL = "INSERT INTO " + c.chCfg.DB + "." + c.taskCfg.TableName + " (" + strings.Join(c.dms, ",") + ") " +
 		"VALUES (" + strings.Join(params, ",") + ")"
 
-	log.Info("%s: Prepare sql=>", c.taskCfg.Name, c.prepareSQL)
+	log.Infof("%s: Prepare sql=> %s", c.taskCfg.Name, c.prepareSQL)
 	return nil
 }

--- a/output/clickhouse.go
+++ b/output/clickhouse.go
@@ -68,7 +68,9 @@ func (c *ClickHouse) Init() error {
 func (c *ClickHouse) Send(batch *model.Batch, callback func(batch *model.Batch) error) {
 	// TODO workerpool parallel
 	statistics.FlushBatchBacklog.WithLabelValues(c.taskCfg.Name).Inc()
-	c.loopWrite(batch, callback)
+	_ = util.GlobalWorkerPool2.Submit(func() {
+		c.loopWrite(batch, callback)
+	})
 }
 
 // Write kvs to clickhouse

--- a/output/clickhouse.go
+++ b/output/clickhouse.go
@@ -142,7 +142,10 @@ func (c *ClickHouse) loopWrite(batch *model.Batch, callback func(batch *model.Ba
 	defer statistics.FlushBatchBacklog.WithLabelValues(c.taskCfg.Name).Dec()
 	for {
 		if err = c.write(batch); err == nil {
-			callback(batch)
+			if err = callback(batch); err!=nil{
+				log.Criticalf("commiting offset failed with error %+v", err)
+				os.Exit(-1)	
+			}
 			return
 		}
 		if std_errors.Is(err, context.Canceled) {

--- a/output/clickhouse.go
+++ b/output/clickhouse.go
@@ -64,14 +64,14 @@ func (c *ClickHouse) Init() error {
 }
 
 // Send a batch to clickhouse
-func (c *ClickHouse) Send(batch model.Batch, callback func(batch model.Batch) error) {
+func (c *ClickHouse) Send(batch *model.Batch, callback func(batch *model.Batch) error) {
 	// TODO workerpool parallel
 	statistics.FlushBatchBacklog.WithLabelValues(c.taskCfg.Name).Inc()
 	c.loopWrite(batch, callback)
 }
 
 // Write kvs to clickhouse
-func (c *ClickHouse) write(batch model.Batch) error {
+func (c *ClickHouse) write(batch *model.Batch) error {
 	if len(batch.MsgRows) == 0 {
 		return nil
 	}
@@ -133,7 +133,7 @@ func shouldReconnect(err error) bool {
 }
 
 // LoopWrite will dead loop to write the records
-func (c *ClickHouse) loopWrite(batch model.Batch, callback func(batch model.Batch) error) {
+func (c *ClickHouse) loopWrite(batch *model.Batch, callback func(batch *model.Batch) error) {
 	var err error
 	times := c.chCfg.RetryTimes
 	defer statistics.FlushBatchBacklog.WithLabelValues(c.taskCfg.Name).Dec()

--- a/output/clickhouse.go
+++ b/output/clickhouse.go
@@ -68,7 +68,7 @@ func (c *ClickHouse) Init() error {
 func (c *ClickHouse) Send(batch *model.Batch, callback func(batch *model.Batch) error) {
 	// TODO workerpool parallel
 	statistics.FlushBatchBacklog.WithLabelValues(c.taskCfg.Name).Inc()
-	_ = util.GlobalWorkerPool2.Submit(func() {
+	_ = util.GlobalWritingPool.Submit(func() {
 		c.loopWrite(batch, callback)
 	})
 }

--- a/pool/conn.go
+++ b/pool/conn.go
@@ -57,7 +57,7 @@ func (c *Connection) ReConnect() error {
 
 var poolMaps = map[string][]*Connection{}
 
-func InitConn(name, hosts string, port int, db, username, password, dsnParams string) (err error) {
+func InitConn(name, hosts string, port int, db, username, password, dsnParams string, blockSize int) (err error) {
 	var ips, ips2, dsnArr []string
 	var sqlDB *sql.DB
 	// if contains ',', that means it's a ip list
@@ -73,8 +73,9 @@ func InitConn(name, hosts string, port int, db, username, password, dsnParams st
 		} else {
 			ip = ips2[0]
 		}
-		dsn := fmt.Sprintf("tcp://%s:%d?database=%s&username=%s&password=%s",
-			ip, port, db, username, password)
+		// Set block_size to max BufferSize of all tasks so that no batch will be split into several blocks.
+		dsn := fmt.Sprintf("tcp://%s:%d?database=%s&username=%s&password=%s&block_size=%d",
+			ip, port, db, username, password, blockSize)
 		if dsnParams != "" {
 			dsn += "&" + dsnParams
 		}

--- a/statistics/statistics.go
+++ b/statistics/statistics.go
@@ -68,14 +68,14 @@ var (
 	RingNormalBatchsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: prefix + "ring_normal_batchs_total",
-			Help: "total num of normal batchs generated",
+			Help: "total num of normal batches generated",
 		},
 		[]string{"task"},
 	)
 	RingForceBatchsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: prefix + "ring_force_batchs_total",
-			Help: "total num of force batchs generated",
+			Help: "total num of force batches generated",
 		},
 		[]string{"task"},
 	)
@@ -131,7 +131,7 @@ var (
 	FlushBatchBacklog = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: prefix + "flush_batch_backlog",
-			Help: "num of batchs pending to flush",
+			Help: "num of batches pending to flush",
 		},
 		[]string{"task"},
 	)

--- a/task/ring.go
+++ b/task/ring.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/fagongzi/goetty"
 	"github.com/pkg/errors"
-	"github.com/segmentio/kafka-go"
 	"github.com/sundy-li/go_commons/log"
 
 	"github.com/housepower/clickhouse_sinker/model"
@@ -70,7 +69,7 @@ type OffsetRange struct {
 func (ring *Ring) ForceBatch(arg interface{}) {
 	var (
 		err    error
-		newMsg *kafka.Message
+		newMsg *model.InputMessage
 		gaps   []OffsetRange
 	)
 
@@ -84,7 +83,7 @@ func (ring *Ring) ForceBatch(arg interface{}) {
 	ring.mux.Lock()
 	defer ring.mux.Unlock()
 	if arg != nil {
-		newMsg = arg.(*kafka.Message)
+		newMsg = arg.(*model.InputMessage)
 		log.Warnf("Ring.ForceBatchAll partition %d message range [%d, %d)", newMsg.Partition, ring.ringGroundOff, newMsg.Offset)
 	}
 	if !ring.isIdle {

--- a/task/task.go
+++ b/task/task.go
@@ -106,9 +106,9 @@ LOOP:
 	service.stopped <- struct{}{}
 }
 
-func (service *Service) fnCommit(partition int, offset int64) {
+func (service *Service) fnCommit(partition int, offset int64) error {
 	msg := model.InputMessage{Topic: service.taskCfg.Topic, Partition: partition, Offset: offset}
-	service.inputer.CommitMessages(service.ctx, &msg)
+	return service.inputer.CommitMessages(service.ctx, &msg)
 }
 
 func (service *Service) put(msg model.InputMessage) {

--- a/task/task.go
+++ b/task/task.go
@@ -175,7 +175,7 @@ func (service *Service) put(msg model.InputMessage) {
 
 	// submit message to a goroutine pool
 	statistics.ParseMsgsBacklog.WithLabelValues(service.taskCfg.Name).Inc()
-	_ = util.GlobalWorkerPool1.Submit(func() {
+	_ = util.GlobalParsingPool.Submit(func() {
 		var row []interface{}
 		p := service.pp.Get()
 		metric, err := p.Parse(msg.Value)

--- a/util/common.go
+++ b/util/common.go
@@ -24,8 +24,8 @@ import (
 
 var (
 	GlobalTimerWheel  *goetty.TimeoutWheel //the global timer wheel
-	GlobalWorkerPool1 *WorkerPool          //the global worker pool for cpu intensive works
-	GlobalWorkerPool2 *WorkerPool          //the global worker pool for network intensive works
+	GlobalParsingPool *WorkerPool          //for all tasks' parsing, cpu intensive
+	GlobalWritingPool *WorkerPool          //the all tasks' writing ClickHouse, cpu-net balance
 )
 
 // InitGlobalTimerWheel initialize the global timer wheel
@@ -33,14 +33,14 @@ func InitGlobalTimerWheel() {
 	GlobalTimerWheel = goetty.NewTimeoutWheel(goetty.WithTickInterval(time.Second))
 }
 
-// InitGlobalWorkerPool1 initialize GlobalWorkerPool1
-func InitGlobalWorkerPool1(maxWorkers int) {
-	GlobalWorkerPool1 = NewWorkerPool(maxWorkers, 10*maxWorkers)
+// InitGlobalParsingPool initialize GlobalParsingPool
+func InitGlobalParsingPool(maxWorkers int) {
+	GlobalParsingPool = NewWorkerPool(maxWorkers, 10*maxWorkers)
 }
 
-// InitGlobalWorkerPool2 initialize GlobalWorkerPool2
-func InitGlobalWorkerPool2(maxWorkers int) {
-	GlobalWorkerPool2 = NewWorkerPool(maxWorkers, 10*maxWorkers)
+// InitGlobalWritingPool initialize GlobalWritingPool
+func InitGlobalWritingPool(maxWorkers int) {
+	GlobalWritingPool = NewWorkerPool(maxWorkers, 10*maxWorkers)
 }
 
 // StringContains check if contains string in array


### PR DESCRIPTION
- Introduced BatchGroup and BatchSys to ensure batches be committed orderly.
- Every batch is routed to a determined clickhouse node. Exit if loop write failed.
- Write batches with goroutine pool.
- Ignore messages left to the learned max offset. This helps to skip duplicated messages during consumer group rebalance.