### PR TITLE
Update value.go

### DIFF
--- a/model/value.go
+++ b/model/value.go
@@ -77,6 +77,17 @@ func WhichType(typ string) (dataType int, nullable bool) {
 		dataType, nullable = ti.Type, ti.Nullable
 		return
 	}
+	
+	//handle FixedString(N) clickhouse type
+	fixedString := strings.HasPrefix(typ, "FixedString(")
+	if fixedString {
+	    ti, ok := typeInfo["String"]
+	    if ok {
+	        dataType, nullable = ti.Type, ti.Nullable
+		return
+	    }
+	}
+	
 	nullable = strings.HasPrefix(typ, "Nullable(")
 	if nullable {
 		typ = typ[len("Nullable(") : len(typ)-1]


### PR DESCRIPTION
The syntax for ClickHouse FixedString type is: FixedString(N)
This leads to "LOGIC ERROR: unsupported ClickHouse data type" error

I assume that any FixedString type is primitive String type