### PR TITLE
Allow to specify http host with config

### DIFF
--- a/util/common.go
+++ b/util/common.go
@@ -43,10 +43,15 @@ var (
 )
 
 type CmdOptions struct {
-	ShowVer          bool
-	LogLevel         string // "debug", "info", "warn", "error", "dpanic", "panic", "fatal"
-	LogPaths         string // comma-separated paths. "stdout" means the console stdout
-	HTTPPort         int    // 0 menas a randomly OS chosen port
+	ShowVer  bool
+	LogLevel string // "debug", "info", "warn", "error", "dpanic", "panic", "fatal"
+	LogPaths string // comma-separated paths. "stdout" means the console stdout
+
+	// HTTPHost to bind to. If empty, outbound ip of machine
+	// is automatically determined and used.
+	HTTPHost string
+	HTTPPort int // 0 means a randomly chosen port.
+
 	PushGatewayAddrs string
 	PushInterval     int
 	LocalCfgFile     string


### PR DESCRIPTION
Real-life example: I was travelling by plane without any network available and was unable to launch sinker as it is.

In this PR:
- add http-host config parameter

Chores:
- fix http port check where we let OS choose the listen port
- separate tcp port check in a separate function, do no use named loop, do not use unbounded loop
- do not explicitly set default values in cmd options
- add space before comments, add dot at the end of comments 
